### PR TITLE
Add social links to share icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,8 +85,9 @@
       <h3>Evolution of refugee populations overtime showing increases and decreases from year to year</h3>
     </div>
     <div class="unhcr-header-social">
-      <a href="#" target="_blank" title="Share on Facebook"><i class="facebook square icon"></i></a>
-      <a href="#" target="_blank" title="Share on Twitter"><i class="twitter square icon"></i></a> 
+      <!-- Links generated with http://www.sharelinkgenerator.com/ -->
+      <a href="https://www.facebook.com/sharer/sharer.php?u=http%3A//unhcr.github.io/dataviz-population-change/" target="_blank" title="Share on Facebook"><i class="facebook square icon"></i></a>
+      <a href="https://twitter.com/home?status=Check%20out%20this%20neat%20%23dataviz%20by%20%40Refugees%20http%3A//unhcr.github.io/dataviz-population-change/" target="_blank" title="Share on Twitter"><i class="twitter square icon"></i></a> 
     </div>
   </div>
 


### PR DESCRIPTION
Closes #80

These links point to the GitHub deployment.

We should probably update the links later to point to the data portal embed page, when it is published.