### PR TITLE
Link to repository from viz page

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,6 +85,7 @@
       <h3>Evolution of refugee populations overtime showing increases and decreases from year to year</h3>
     </div>
     <div class="unhcr-header-social">
+      <a href="https://github.com/unhcr/dataviz-population-change" target="_blank" title="View Source Code on GitHub"><i class="github square icon"></i></a>
       <a href="#" target="_blank" title="Share on Facebook"><i class="facebook square icon"></i></a>
       <a href="#" target="_blank" title="Share on Twitter"><i class="twitter square icon"></i></a> 
     </div>


### PR DESCRIPTION
Closes #26

This lets people easily navigate to the GitHub repository from the dataviz page.